### PR TITLE
Quick fix

### DIFF
--- a/src/web_app/package.json
+++ b/src/web_app/package.json
@@ -26,7 +26,7 @@
     "test": "react-scripts test",
     "coverage": "react-scripts test --no-watchman --reporter=html --coverage --watchAll=false",
     "coverage-ci": "react-scripts test --no-watchman --reporter=lcovonly --coverage --watchAll=false",
-    "lint": "eslint ./**/*.ts ./**/*.tsx --fix"
+    "lint": "eslint './**/*.ts' './**/*.tsx' --fix"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
I found out that ESLint did not correctly recognize the `./**/*` pattern, making the linting process pretty much useless. So I fixed it :)

 - Fixed ESLint not recognizing the ** pattern.