### PR TITLE
Fixed coverage to make it also use python 9

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,10 +15,10 @@ jobs:
     
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python 3.9
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.9"
     - name: Set up node 16
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
Just saw that the coverage workflow had a bug. As with the other python workflow, it was using python 3.10 instead of python 3.9. This PR just fix this.