### PR TITLE
Mutate and crossover operators

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,3 +5,4 @@ exclude =
     venv,
     src/web_app
 max-line-length = 120
+format = pylint

--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,7 @@ coverage.xml
 *.lcov
 bandit.html
 pylint.txt
-flake8.tkt
+flake8.txt
 pydocstyle.txt
 
 # Translations

--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,8 @@ clean:
 lint:
 	$(PY_CONDA) -m bandit -c ./bandit.yaml -r -f html -o bandit.html .
 	$(PY_CONDA) -m pylint --exit-zero src/cvrp src/server test/ >pylint.txt
-	$(PY_CONDA) -m flake8 . --output-file=flake8.txt
-	$(PY_CONDA) -m pydocstyle . -e -s > pydocstyle.txt || exit 0
+	$(PY_CONDA) -m flake8 . --output-file=flake8.txt || exit 0
+	$(PY_CONDA) -m pydocstyle ./**/* -e -s > pydocstyle.txt || exit 0
 	
 
 

--- a/flake8.txt
+++ b/flake8.txt
@@ -1,0 +1,3 @@
+.\src\cvrp\ecvrp.py:170: [E501] line too long (128 > 120 characters)
+.\src\cvrp\ecvrp.py:199: [F841] local variable 'road1' is assigned to but never used
+.\src\cvrp\ecvrp.py:200: [F841] local variable 'road2' is assigned to but never used

--- a/flake8.txt
+++ b/flake8.txt
@@ -1,3 +1,6 @@
 .\src\cvrp\ecvrp.py:170: [E501] line too long (128 > 120 characters)
 .\src\cvrp\ecvrp.py:199: [F841] local variable 'road1' is assigned to but never used
 .\src\cvrp\ecvrp.py:200: [F841] local variable 'road2' is assigned to but never used
+.\src\cvrp\ecvrp.py:257: [W293] blank line contains whitespace
+.\src\cvrp\ecvrp.py:301: [W291] trailing whitespace
+.\src\cvrp\ecvrp.py:301: [W291] trailing whitespace

--- a/flake8.txt
+++ b/flake8.txt
@@ -1,6 +1,0 @@
-.\src\cvrp\ecvrp.py:170: [E501] line too long (128 > 120 characters)
-.\src\cvrp\ecvrp.py:199: [F841] local variable 'road1' is assigned to but never used
-.\src\cvrp\ecvrp.py:200: [F841] local variable 'road2' is assigned to but never used
-.\src\cvrp\ecvrp.py:257: [W293] blank line contains whitespace
-.\src\cvrp\ecvrp.py:301: [W291] trailing whitespace
-.\src\cvrp\ecvrp.py:301: [W291] trailing whitespace

--- a/src/cvrp/constraints_validators.py
+++ b/src/cvrp/constraints_validators.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
-This module holds the various constraint validators used to configure the ECVRP
+This module holds the various constraint validators used to configure the ECVRP.
 
 @author: Cyril Obrecht
 @license: GPL-3
@@ -32,11 +32,11 @@ from .ecvrp import ECVRPSolution
 
 # pylint: disable=too-few-public-methods
 class BatteryTWValidator(ConstraintValidator[ECVRPSolution]):
-    """
-    Class in charge of checking if the battery capacity is never exceeded
-    and if the time windows are respected
-    """
+    """Class in charge of checking if the battery capacity is never exceeded \
+    and if the time windows are respected."""
+
     def is_valid(self, individual: ECVRPSolution) -> bool:
+        """Check the validity of an individual according to the rules this instance implement."""
         instance = individual.get_instance()
         for road in individual.get_roads():
             latest = road[0]
@@ -66,19 +66,26 @@ class BatteryTWValidator(ConstraintValidator[ECVRPSolution]):
 
 # pylint: disable=too-few-public-methods
 class VehiculeCountValidator(ConstraintValidator[ECVRPSolution]):
+    """Class in charge of checking if the number of vehicule used is conform."""
+
     def is_valid(self, individual: ECVRPSolution) -> bool:
+        """Check the validity of an individual according to the rules this instance implement."""
         return len(individual.get_roads()) <= individual.get_instance().get_ev_count()
 
 
 # pylint: disable=too-few-public-methods
 class TownUnicityValidator(ConstraintValidator[ECVRPSolution]):
-    """ Class in charge of checking if each town is only present exactly one time in the solution.
-        Depots and chargers are ignored.
-        This validator has a terrible complexity and is not intended to be used during the GA.
-        It is intended to be used to check if the first generation is valid,
-        the following generation should be build valdid according to this class.
     """
+    Class in charge of checking if each town is only present exactly one time in the solution.
+
+    Depots and chargers are ignored.
+    This validator has a terrible complexity and is not intended to be used during the GA.
+    It is intended to be used to check if the first generation is valid,
+    the following generation should be build valdid according to this class.
+    """
+
     def is_valid(self, individual: ECVRPSolution) -> bool:
+        """Check the validity of an individual according to the rules this instance implement."""
         instance = individual.get_instance()
         visited = set()
         for i in individual.get_points():
@@ -90,9 +97,10 @@ class TownUnicityValidator(ConstraintValidator[ECVRPSolution]):
 
 
 class CapacityValidator(ConstraintValidator[ECVRPSolution]):
-    """ Class in charge of checking if the cargo capacity of the EVs is not exceeded
-    """
+    """Class in charge of checking if the cargo capacity of the EVs is not exceeded."""
+
     def is_valid(self, individual: ECVRPSolution) -> bool:
+        """Check the validity of an individual according to the rules this instance implement."""
         instance = individual.get_instance()
         for road in individual.get_roads():
             capacity = instance.get_ev_capacity()

--- a/src/cvrp/constraints_validators.py
+++ b/src/cvrp/constraints_validators.py
@@ -43,7 +43,7 @@ class BatteryTWValidator(ConstraintValidator[ECVRPSolution]):
             battery = instance.get_ev_battery()
             time = 0.
             for i in road:
-                battery -= instance.get_batterie_consuption(latest, i)
+                battery -= instance.get_batterie_consumption(latest, i)
                 if battery < 0:
                     return False
 

--- a/src/cvrp/ecvrp.py
+++ b/src/cvrp/ecvrp.py
@@ -6,8 +6,8 @@ the genetic algorithm applyed to the ECVRP problem.
 
 @author: Cyril Obrecht and Marie Aspro
 @license: GPL-3
-@date: 2022-11-17
-@version: 0.6
+@date: 2022-11-22
+@version: 0.7
 """
 
 # CVRP

--- a/src/cvrp/ecvrp.py
+++ b/src/cvrp/ecvrp.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
-This module holds parts of the implementation of
+This module holds parts of the implementation of \
 the genetic algorithm applyed to the ECVRP problem.
 
 @author: Cyril Obrecht and Marie Aspro
@@ -33,9 +33,11 @@ import random
 
 
 class ECVRPSolution(Individual["ECVRPSolution"]):
-    """ Holds a solution to the ECVRP problem and methods to help with a GA
-        Mutations is either done via 2-opt or a special algorithm.
-        See the mutate method for more information on this subject
+    """
+    Holds a solution to the ECVRP problem and methods to help with a GA.
+
+    Mutations is either done via 2-opt or a special algorithm.
+    See the mutate method for more information on this subject.
     """
 
     _roads: Union[tuple[tuple[int, ...], ...], None]
@@ -49,6 +51,14 @@ class ECVRPSolution(Individual["ECVRPSolution"]):
             solution: list[int],
             instance: "ECVRPInstance"
             ) -> None:
+        """
+        Initialise the ECVRPSolution class.
+
+        :param validators: A list of validator used to determine if the instance is valid.
+        This list will be trasmitted to children.
+        :param solution: A list of indexes that represent a solution to the ECVRP instace
+        :param instance: The instance this object aims to represent a solution.
+        """
         super().__init__(validators)
         self._solution = solution
         self.__instance = instance
@@ -56,15 +66,16 @@ class ECVRPSolution(Individual["ECVRPSolution"]):
         self._fitness = None
 
     def get_instance(self) -> "ECVRPInstance":
+        """Return the instance linked to this solution."""
         return self.__instance
 
     def get_points(self) -> tuple[int, ...]:
+        """Return the solution in an imutable form."""
         return tuple(self._solution)
 
     def get_roads(self) -> tuple[tuple[int, ...], ...]:
-        """ Split the solution in individual roads that can be manipulated
-            without altering the main object.
-        """
+        """Split the solution in individual roads that can be manipulated \
+        without altering the main object."""
         if self._roads is not None:
             return self._roads
 
@@ -84,10 +95,12 @@ class ECVRPSolution(Individual["ECVRPSolution"]):
         return self._roads
 
     def get_fitness(self) -> float:
-        """ Compute the fitness of the solution held in this individual
-            The fitness is here defined as the maximum amount
-            of time taken by an EV to travel a road.
-            The time taken to go from the town A to B is equals to the distance between those towns
+        """
+        Compute the fitness of the solution held in this individual.
+
+        The fitness is here defined as the maximum amount
+        of time taken by an EV to travel a road.
+        The time taken to go from the town A to B is equals to the distance between those towns.
         """
         if self._fitness is not None:
             return self._fitness
@@ -169,19 +182,24 @@ class ECVRPSolution(Individual["ECVRPSolution"]):
                 list_temp.append(point)
         return new_solution
 
-    def mutate(self, S: list[int]) -> list[int]:
-        """ Mutate the current individual according to its internal rules.
-            This changement is done in place.
+    def mutate(self) -> None:
+        """
+        Mutate the current individual according to its internal rules.
+
+        This changement is done in place.
         """
         S = self.cutInRoads(S)
         # TODO : continue here
         return S
 
-    def crossover(self, S1: list[int], S2: list[int]) -> list[TypeIndividual]:
-        """ Generate a list of children according to the rules of the individual.
-            The returned list might be empty or contains duplicated children.
-            This function might not return the same result with the same argument and
-            will probably not be comutative.
+
+    def crossover(self, S2: TypeIndividual) -> list[TypeIndividual]:
+         """
+        Generate a list of children according to the rules of the individual.
+
+        The returned list might be empty or contains duplicated children.
+        This function might not return the same result with the same argument and
+        will probably not be comutative.
         """
         S1 = self.cutInRoads(S1)
         S2 = self.cutInRoads(S2)
@@ -198,9 +216,11 @@ class ECVRPSolution(Individual["ECVRPSolution"]):
         # TODO : continue here
 
     def is_valid(self) -> bool:
+        """Run all of its validator and return False if one of them fail."""
         return len([v for v in self._validators if not v.is_valid(self)]) == 0
 
     def __copy__(self) -> "ECVRPSolution":
+        """Create a copy."""
         copy = ECVRPSolution(list(self._validators), list(self._solution), self.__instance)
         copy._fitness = self._fitness
         copy._roads = self._roads
@@ -208,9 +228,7 @@ class ECVRPSolution(Individual["ECVRPSolution"]):
 
 
 class ECVRPInstance:
-    """
-        holding class for most of the information that describe an instance of the ECVRP problem
-    """
+    """Holding class for most of the information that describe an instance of the ECVRP problem."""
 
     __d_matrix: list[list[float]]
     __depot: int
@@ -236,6 +254,7 @@ class ECVRPInstance:
             ev_battery: float,
             time_windows: dict[int, tuple[float, float]]
             ) -> None:
+        """Initialize the instance class."""
         self.__d_matrix = distance_matrix
         self.__depot = depot_id
         self.__chargers = chargers
@@ -248,39 +267,56 @@ class ECVRPInstance:
         self.__time_windows = time_windows
 
     def is_depot(self, index: int) -> bool:
+        """Return True if the given index is a depot."""
         return index == self.__depot
 
     def get_distance(self, start: int, end: int) -> float:
+        """Return the distance between start and end."""
         return self.__d_matrix[start][end]
 
     def get_time_used(self, start: int, end: int) -> float:
+        """Return the time took by a vehicule to go from start to end."""
         return self.__d_matrix[start][end]
 
     def is_charger(self, index: int) -> bool:
+        """Return True if the given index is a charger."""
         return index in self.__chargers
 
     def get_demand(self, index: int) -> int:
+        """
+        Return the demand of the point at the given index.
+
+        May raise an exception if the index is a depot or a charger.
+        Will raise one if the index is out of bounds
+        """
         return self.__demands[index]
 
     def get_batterie_consumption(self, start: int, end: int) -> int:
+        """Return the amount of energy consumed by a vehicule to go from start to end."""
         return round(self.get_distance(start, end) * self.__bat_cost)
 
     def get_batterie_charging_rate(self) -> float:
+        """Return the speed at witch betteries charges."""
         return self.__bat_charge
 
     def get_ev_count(self) -> float:
+        """Return the maximum number of EV allowed."""
         return self.__ev_count
 
     def get_ev_capacity(self) -> float:
+        """Return the cargot capacity of an EV."""
         return self.__ev_capacity
 
     def get_ev_battery(self) -> float:
+        """Return the battery capacity of an EV."""
         return self.__ev_battery
 
     def get_tw(self, index: int) -> tuple[float, float]:
+        """Return tha time window to deliver the point at the given index."""
         return self.__time_windows[index]
 
     def get_towns(self) -> list[int]:
+        """Return all points that are not a depot or a charger."""
         return [
             i for i in range(len(self.__d_matrix)) if not (self.is_depot(i) or self.is_charger(i))
         ]

--- a/src/cvrp/ecvrp.py
+++ b/src/cvrp/ecvrp.py
@@ -7,8 +7,8 @@ the genetic algorithm applyed to the ECVRP problem.
 @author: Cyril Obrecht
 @author: Marie Aspro
 @license: GPL-3
-@date: 2022-11-29
-@version: 0.9
+@date: 2022-12-03
+@version: 1.0
 """
 
 # CVRP
@@ -179,7 +179,9 @@ class ECVRPSolution(Individual["ECVRPSolution"]):
         """
         list_chargers = self.__instance.get_chargers()
         if not list_chargers:
-            return self.__instance.get_depot()
+            size = len(self.get_roads())
+            if self.__instance.get_ev_count() > size:
+                return self.__instance.get_depot()
 
         d_min = float("inf")
         closest = -1

--- a/src/cvrp/ecvrp.py
+++ b/src/cvrp/ecvrp.py
@@ -122,16 +122,16 @@ class ECVRPSolution(Individual["ECVRPSolution"]):
         if (not listChargers):
             return self.__depot
         else:
-            d_min = get_distance(point, listChargers[0])
+            d_min = self.get_distance(point, listChargers[0])
             closest = listChargers[0]
             for charger in listChargers:
-                dist = get_distance(point, charger)
+                dist = self.get_distance(point, charger)
                 if (dist < d_min):
                     d_min = dist
                     closest = charger
             return closest
 
-    def last(road: list[int]) -> int:
+    def last(self, road: list[int]) -> int:
         """ Useful function that will return the last point of a road."""
         return road[-1]
 
@@ -143,16 +143,16 @@ class ECVRPSolution(Individual["ECVRPSolution"]):
         validRoad = [int]
         b = Battery
         for point in road:
-            charger = closestCharger(point)
-            if (b - get_batterie_consumption(last(validRoad), point) < get_batterie_consumption(point, charger)):
-                validRoad.append(closestCharger(last(validRoad)))
+            charger = self.closestCharger(point)
+            if (b - self.get_batterie_consumption(self.last(validRoad), point) < self.get_batterie_consumption(point, charger)):
+                validRoad.append(self.closestCharger(self.last(validRoad)))
                 b = Battery
-            b = b - get_batterie_consumption(last(validRoad), point)
+            b = b - self.get_batterie_consumption(self.last(validRoad), point)
             validRoad.append(point)
         return validRoad
 
     def cutInRoads(self, solution: list[int]) -> list[list[int]]:
-        """ cutInRoads have to cut a list of solution made of more than 1 road 
+        """ cutInRoads have to cut a list of solution made of more than 1 road
             (mean : you are going to the depot more than when you begin and you end)
             in a list of road (which are already smaller list).
         """
@@ -173,7 +173,7 @@ class ECVRPSolution(Individual["ECVRPSolution"]):
         """ Mutate the current individual according to its internal rules.
             This changement is done in place.
         """
-        S = cutInRoads(S)
+        S = self.cutInRoads(S)
         # TODO : continue here
         return S
 
@@ -183,12 +183,18 @@ class ECVRPSolution(Individual["ECVRPSolution"]):
             This function might not return the same result with the same argument and
             will probably not be comutative.
         """
-        S1 = cutInRoads(S1)
-        S2 = cutInRoads(S2)
+        S1 = self.cutInRoads(S1)
+        S2 = self.cutInRoads(S2)
         num_r1 = random(0, len(S1))
         num_r2 = random(0, len(S2))
         road1 = list(map(lambda r: r[num_r1], S1))
         road2 = list(map(lambda r: r[num_r2], S2))
+        
+        size_S1 = len(S1)
+        for row in range(size_S1):
+            for col in range(size_S1):
+                
+
         # TODO : continue here
 
     def is_valid(self) -> bool:

--- a/src/cvrp/ecvrp.py
+++ b/src/cvrp/ecvrp.py
@@ -6,8 +6,8 @@ the genetic algorithm applyed to the ECVRP problem.
 
 @author: Cyril Obrecht and Marie Aspro
 @license: GPL-3
-@date: 2022-11-10
-@version: 0.2
+@date: 2022-11-16
+@version: 0.3
 """
 
 # CVRP

--- a/src/cvrp/ecvrp.py
+++ b/src/cvrp/ecvrp.py
@@ -7,7 +7,7 @@ the genetic algorithm applyed to the ECVRP problem.
 @author: Cyril Obrecht and Marie Aspro
 @license: GPL-3
 @date: 2022-11-17
-@version: 0.5
+@version: 0.6
 """
 
 # CVRP

--- a/src/cvrp/ga.py
+++ b/src/cvrp/ga.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+
+"""
+This module holds parts of the implementation of \
+the genetic algorithm applyed to the ECVRP problem.
+
+@author: Cyril Obrecht
+@license: GPL-3
+@date: 2022-11-02
+@version: 0.1
+"""
+
+# CVRP
+# Copyright (C) 2022  A.Marie, K.Sonia, M.Jean, O.Cyril, V.Axel
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Generic
+import random
+import time
+from .individual import TypeIndividual
+
+
+class GA(Generic[TypeIndividual]):
+    """
+    Class in charge of the main logic.
+
+    This class will breed and select various individual accros many generations.
+    """
+
+    def __init__(
+                self,
+                initial: list[TypeIndividual],
+                mutation_rate: float,
+                seed: int = None
+            ):
+        """
+        Initialize the GA class.
+
+        :param initial: The initial state of the GA: the first generation of individuals.
+        :param mutation_rate: The percents of chance that a child is mutated.
+        :param seed: The seed used to seed the random generator used by this class.
+        """
+        self._current_pop = initial
+
+        if not 0 < mutation_rate < 1:
+            raise ValueError("The mutation_rate rate must be between 0 and 1")
+        self._mutation_rate = mutation_rate
+
+        if seed is None:
+            seed = time.thread_time_ns()
+
+        random.seed(seed)
+
+        self._len = 0
+
+    def run(self, generations: int):
+        """
+        Run the Ga algorithm.
+
+        this method will breed n generation and return each generation.
+        """
+        self._len = generations
+
+        self._current_pop.sort()
+
+        parents_count = len(self._current_pop) // 2
+        children_count = len(self._current_pop) - parents_count
+
+        for _ in range(generations):
+            fitnesses = [i.get_fitness() for i in self._current_pop]
+            sum_fit = sum(fitnesses)
+
+            cum = [0]*len(fitnesses)
+            parents = [None] * parents_count
+
+            for j in range(parents_count):
+                for i, fit in enumerate(fitnesses):
+                    cum[i] = fit/sum_fit + (cum[i - 1] if i > 0 else 0)
+
+                index = 0
+                randi = random.random()
+                while cum[index] < randi:
+                    index += 1
+                parents[j] = self._current_pop[index]
+
+                fitnesses.pop(index)
+
+            children = self._mutate(self._crossbreed(parents, children_count))
+            self._current_pop = [*parents, *children]
+            self._current_pop.sort()
+            yield self._current_pop
+
+    def _crossbreed(self, parents: list[TypeIndividual], count: int) -> list[TypeIndividual]:
+        children = []
+        while len(children) < count:
+
+            first = random.randint(0, len(parents)-1)
+            second = first
+            while first == second:
+                second = random.randint(0, len(parents)-1)
+
+            children.extend(parents[first].crossover(parents[second]))
+
+        return children
+
+    def _mutate(self, children: list[TypeIndividual]) -> list[TypeIndividual]:
+        for child in children:
+            if random.random() < self._mutation_rate:
+                child.mutate()
+        return children
+
+    def __len__(self):
+        """Rturns he number of iteration given to the run method."""
+        return self._len

--- a/src/cvrp/individual.py
+++ b/src/cvrp/individual.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
-""" This module holds the abstract class Individual and the ConstraintValidator interface
+"""
+This module holds the abstract class Individual and the ConstraintValidator interface.
+
 The Individual class represent a generic individual that is deseigned to be used
 with our current genetic algorithm implementation. Constraint Validators offer a generic,
 and modulable way to check if an individual holds a valid solution.
@@ -37,45 +39,50 @@ TypeIndividual = TypeVar("TypeIndividual", bound="Individual")
 # According to the class diagram aprooved by the team this is normal.
 # pylint: disable=too-few-public-methods
 class ConstraintValidator(ABC, Generic[TypeIndividual]):
-    """ Interface providing a standard methods to check if an Individual holds a valid solution
-    """
+    """Interface providing a standard methods to check if an Individual holds a valid solution."""
 
     @abstractmethod
     def is_valid(self, individual: TypeIndividual) -> bool:
-        """
-            Check the validity of an individual according to the rules this instance implement
-        """
+        """Check the validity of an individual according to the rules this instance implement."""
 
 
 class Individual(Generic[TypeIndividual], ABC):
-    """
-    Abstract class handling the concept of individual in our implementation of a Genetic algorithm
-    """
+    """Abstract class handling the concept of individual in our implementation of \
+    a Genetic algorithm."""
 
     def __init__(self, validators: list["ConstraintValidator"]) -> None:
+        """
+        Abstract class handling the concept of individual in our implementation of \
+        a Genetic algorithm.
+
+        :param validators: A list of validator used to determine if the instance is valid.
+        This list will be trasmitted to children.
+        """
         super().__init__()
         self._validators = validators
 
     @abstractmethod
     def get_fitness(self) -> float:
-        """ Return the fitness of the individual.
-        """
+        """Return the fitness of the individual."""
 
     @abstractmethod
     def mutate(self) -> None:
-        """ Mutate the current individual according to its internal rules.
-            This changement is done in place.
+        """
+        Mutate the current individual according to its internal rules.
+
+        This changement is done in place.
         """
 
     @abstractmethod
     def crossover(self, other: TypeIndividual) -> list[TypeIndividual]:
-        """ Generate a list of children according to the rules of the individual.
-            The returned list might be empty or contains duplicated children.
-            This function might not return the same result with the same argument and
-            will probably not be comutative.
+        """
+        Generate a list of children according to the rules of the individual.
+
+        The returned list might be empty or contains duplicated children.
+        This function might not return the same result with the same argument and
+        will probably not be comutative.
         """
 
     @abstractmethod
     def __copy__(self) -> TypeIndividual:
-        """ Produce a copy of the individual.
-        """
+        """Produce a copy of the individual."""

--- a/src/cvrp/json_io.py
+++ b/src/cvrp/json_io.py
@@ -27,6 +27,7 @@ This module holds the IO handlers for our data storage.
 
 from pathlib import Path
 from bz2 import BZ2File
+from typing import Union
 import json
 
 from .ecvrp import ECVRPSolution
@@ -57,7 +58,8 @@ class JsonWriter:
         self.__name = name
         self.__bench_name = bench_name
 
-    def add_snapshot(self, snapshot: list[ECVRPSolution], time: float):
+    def add_snapshot(self, snapshot: list[ECVRPSolution], time: float) \
+            -> dict[str, Union[str, list[dict[str, Union[int, tuple[int]]]]]]:
         """
         Add a snapshot to the structure.
 
@@ -74,6 +76,8 @@ class JsonWriter:
             })
 
         self.__snapshots.append(generation)
+
+        return generation
 
     def dump(self):
         """

--- a/src/cvrp/json_io.py
+++ b/src/cvrp/json_io.py
@@ -59,7 +59,7 @@ class JsonWriter:
         self.__bench_name = bench_name
 
     def add_snapshot(self, snapshot: list[ECVRPSolution], time: float) \
-            -> dict[str, Union[str, list[dict[str, Union[int, tuple[int]]]]]]:
+            -> dict[str, Union[float, list[dict[str, Union[int, tuple[int, ...]]]]]]:
         """
         Add a snapshot to the structure.
 

--- a/src/cvrp/json_io.py
+++ b/src/cvrp/json_io.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+
+"""
+This module holds the IO handlers for our data storage.
+
+@author: Cyril Obrecht
+@license: GPL-3
+@date: 2022-11-02
+@version: 0.1
+"""
+
+# CVRP
+# Copyright (C) 2022  A.Marie, K.Sonia, M.Jean, O.Cyril, V.Axel
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+from bz2 import BZ2File
+import json
+
+from .ecvrp import ECVRPSolution
+
+
+class JsonWriter:
+    """
+    Class handling the writing of information to a specific JSON file with pre defined structure.
+
+    In order to limit the space cost of those files they are compressed with bz2.
+    """
+
+    def __init__(
+                self,
+                root: str,
+                name: str,
+                bench_name: str
+            ):
+        """
+        Initialize the JsonWriter class.
+
+        :param root: Base folder to save files to.
+        :param name: Name of the file to store the data in.
+        :param bench_id: The unique ID of the benchmark that produced this result.
+        """
+        self.__snapshots = []
+        self.__root = Path(root)
+        self.__name = name
+        self.__bench_name = bench_name
+
+    def add_snapshot(self, snapshot: list[ECVRPSolution], time: float):
+        """
+        Add a snapshot to the structure.
+
+        The snapshots are dumped in the same order as provided.
+        Hence if you want to retrosctively add new snapshots between existing,
+        make sure that you handle this at read time.
+        """
+        generation = {"time": time, "individuals": []}
+
+        for individual in snapshot:
+            generation["individuals"].append({
+                "solution": individual.get_points(),
+                "fitness": individual.get_fitness()
+            })
+
+        self.__snapshots.append(generation)
+
+    def dump(self):
+        """
+        Dump all the collected data to the file name `root/name.json.bz2`.
+
+        This method will override any existing file without warning.
+        """
+        data = {
+            "bench_id": self.__bench_name,
+            "snapshots": self.__snapshots
+        }
+        with BZ2File(str(self.__root.joinpath(f"{self.__name}.json.bz2")), "wb") as file:
+            dump = json.dumps(data, separators=(",", ":")).encode("U7")
+            file.write(dump)
+            file.close()
+
+
+def read_json(root: str, name: str) -> dict[str, any]:
+    """Read a JSON file and recover snapshots."""
+    root = Path(root)
+    data: bytes
+
+    with BZ2File(str(root.joinpath(f"{name}.json.bz2")), "rb") as file:
+        data = file.read()
+        file.close()
+
+    return json.loads(data.decode("U7"))

--- a/src/server/__init__.py
+++ b/src/server/__init__.py
@@ -1,0 +1,5 @@
+"""
+Good documentation should be placed here.
+
+I honestly don't know what I should document here
+"""

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,1 @@
+"""Good documentation should be placed here."""

--- a/test/cvrp/test_ecvrp.py
+++ b/test/cvrp/test_ecvrp.py
@@ -6,7 +6,7 @@ This module holds tests for the cvrp.ecvrp module.
 @author: Cyril Obrecht
 @author: Marie Aspro
 @license: GPL-3
-@date: 2022-11-28
+@date: 2022-11-29
 @version: 0.2
 """
 
@@ -226,9 +226,22 @@ def test_crossover():
 
     [enfant_1, enfant_2] = parent_1.crossover(parent_2)
 
-    assert enfant_1.get_points() == (0, 0, 0)
-    assert enfant_2.get_points() == (0, 0, 0)
+    assert enfant_1.get_fitness() == 4
+    assert enfant_2.get_fitness() == 4
+
+    assert enfant_1.get_roads() == ((0, 2, 0), (0, 3, 4, 0))
+    assert enfant_2.get_roads() == ((0, 3, 4, 0), (0, 2, 0))
 
 
 def test_mutation():
-    assert True
+    random.seed(3)
+
+    mutant = ECVRPSolution([], [0, 4, 1, 2, 0, 3, 0], test_instance)
+
+    print("mutant.get_roads() avant : ", mutant.get_roads())
+
+    mutant.mutate()
+
+    print("mutant.get_roads() après : ", mutant.get_roads())
+
+    assert mutant.get_roads() == ((0, 2, 4, 0), (0, 3, 0))

--- a/test/cvrp/test_ecvrp.py
+++ b/test/cvrp/test_ecvrp.py
@@ -6,8 +6,8 @@ This module holds tests for the cvrp.ecvrp module.
 @author: Cyril Obrecht
 @author: Marie Aspro
 @license: GPL-3
-@date: 2022-11-29
-@version: 0.2
+@date: 2022-12-03
+@version: 0.3
 """
 
 # CVRP
@@ -37,7 +37,7 @@ from src.cvrp.constraints_validators import\
     TownUnicityValidator,\
     CapacityValidator
 
-test_instance = ECVRPInstance(
+test_instance_1 = ECVRPInstance(
     [
         [0, 1, 2, 2, 2],
         [3, 0, 1, 3, 2],
@@ -65,6 +65,33 @@ test_instance = ECVRPInstance(
 )
 
 
+test_instance_2 = ECVRPInstance(
+    [
+        [0, 2, 4, 7],
+        [2, 0, 6, 9],
+        [4, 6, 0, 5],
+        [7, 9, 5, 0]
+    ],
+    0,
+    {},
+    {
+        1: 1,
+        2: 1,
+        3: 1,
+    },
+    1,
+    3,
+    3,
+    10,
+    14,
+    {
+        1: (),
+        2: (),
+        3: ()
+    }
+)
+
+
 def test_road_building():
     """ Test the road building process: ensure the count is right.
     """
@@ -76,7 +103,7 @@ def test_road_building():
         10: [0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8, 0, 9, 0, 10, 0]
     }
     for count, solution in solutions.items():
-        test = ECVRPSolution([], solution, test_instance)
+        test = ECVRPSolution([], solution, test_instance_1)
         assert len(test.get_roads()) == count
 
 
@@ -95,7 +122,7 @@ def test_road_content():
     ]
 
     for expected in roads_expected:
-        instance = ECVRPSolution([], expected["source"], test_instance)
+        instance = ECVRPSolution([], expected["source"], test_instance_1)
         roads = instance.get_roads()
         for i, road in enumerate(expected["roads"]):
             assert road == roads[i]
@@ -105,13 +132,13 @@ def test_fitness():
     """ Test if the fitness computation is good.
     """
 
-    instance = ECVRPSolution([], [0, 2, 3, 0, 4, 1, 0], test_instance)
+    instance = ECVRPSolution([], [0, 2, 3, 0, 4, 1, 0], test_instance_1)
     assert instance.get_fitness() == 8
 
-    instance = ECVRPSolution([], [0, 2, 3, 4, 1, 0], test_instance)
+    instance = ECVRPSolution([], [0, 2, 3, 4, 1, 0], test_instance_1)
     assert instance.get_fitness() == 11
 
-    instance = ECVRPSolution([], [0, 4, 3, 0, 2, 1, 0], test_instance)
+    instance = ECVRPSolution([], [0, 4, 3, 0, 2, 1, 0], test_instance_1)
     assert instance.get_fitness() == 7
 
 
@@ -126,35 +153,35 @@ def test_is_valid():
     assert ECVRPSolution(
         [town],
         [0, 4, 3, 0, 2, 1, 0],
-        test_instance
+        test_instance_1
     ).is_valid()
     assert ECVRPSolution(
         [town, capacity],
         [0, 4, 3, 0, 2, 1, 0],
-        test_instance
+        test_instance_1
     ).is_valid()
     assert ECVRPSolution(
         [town, capacity, count],
         [0, 4, 3, 0, 2, 1, 0],
-        test_instance
+        test_instance_1
     ).is_valid()
 
     assert not ECVRPSolution(
         [town, capacity, count],
         [0, 4, 3, 0, 2, 1, 2, 0],
-        test_instance
+        test_instance_1
     ).is_valid()
 
     assert not ECVRPSolution(
         [town, capacity, count],
         [0, 4, 3, 1, 2, 0],
-        test_instance
+        test_instance_1
     ).is_valid()
 
     assert not ECVRPSolution(
         [town, capacity, count],
         [0, 4, 3, 0, 2, 1, 0, 0, 0],
-        test_instance
+        test_instance_1
     ).is_valid()
 
 
@@ -168,12 +195,12 @@ def test_copy():
     instance_1 = ECVRPSolution(
         [town, capacity, count],
         [0, 4, 3, 0, 2, 1, 0],
-        test_instance
+        test_instance_1
     )
     instance_2 = ECVRPSolution(
         [town, capacity, count],
         [0, 4, 3, 1, 2, 0],
-        test_instance
+        test_instance_1
     )
 
     instance_1_copy = copy(instance_1)
@@ -193,36 +220,36 @@ def test_d_matrix():
     """ Test the distance matrix of the ECVRPInstance class.
     """
 
-    assert test_instance.get_distance(0, 1) == 1
-    assert test_instance.get_distance(0, 2) == 2
-    assert test_instance.get_distance(1, 0) == 3
+    assert test_instance_1.get_distance(0, 1) == 1
+    assert test_instance_1.get_distance(0, 2) == 2
+    assert test_instance_1.get_distance(1, 0) == 3
 
 
 def test_depot():
-    assert test_instance.is_depot(0)
-    assert not test_instance.is_depot(1)
+    assert test_instance_1.is_depot(0)
+    assert not test_instance_1.is_depot(1)
 
 
 def test_demand():
     """ Test the `get_demand` function of the ECVRPInstance class.
     """
 
-    assert test_instance.get_demand(2) == 5
+    assert test_instance_1.get_demand(2) == 5
 
     with pytest.raises(KeyError):
-        test_instance.get_demand(0)
+        test_instance_1.get_demand(0)
 
 
 def test_charger():
-    assert test_instance.is_charger(1)
-    assert not test_instance.is_charger(2)
+    assert test_instance_1.is_charger(1)
+    assert not test_instance_1.is_charger(2)
 
 
 def test_crossover():
     random.seed(8)
 
-    parent_1 = ECVRPSolution([], [0, 4, 2, 0, 3, 1, 0], test_instance)
-    parent_2 = ECVRPSolution([], [0, 2, 3, 0, 1, 4, 0], test_instance)
+    parent_1 = ECVRPSolution([], [0, 4, 2, 0, 3, 1, 0], test_instance_1)
+    parent_2 = ECVRPSolution([], [0, 2, 3, 0, 1, 4, 0], test_instance_1)
 
     [enfant_1, enfant_2] = parent_1.crossover(parent_2)
 
@@ -236,7 +263,7 @@ def test_crossover():
 def test_mutation():
     random.seed(3)
 
-    mutant = ECVRPSolution([], [0, 4, 1, 2, 0, 3, 0], test_instance)
+    mutant = ECVRPSolution([], [0, 4, 1, 2, 0, 3, 0], test_instance_1)
 
     print("mutant.get_roads() avant : ", mutant.get_roads())
 
@@ -245,3 +272,17 @@ def test_mutation():
     print("mutant.get_roads() après : ", mutant.get_roads())
 
     assert mutant.get_roads() == ((0, 2, 4, 0), (0, 3, 0))
+
+
+def test_empty_road():
+    instance = ECVRPSolution([], [0, 4, 1, 0, 2, 3, 0, 0], test_instance_1)
+    solution = instance.get_roads()
+    solution = [list(x) for x in solution]
+    assert instance.delete_empty_road(solution) == [[0, 4, 1, 0], [0, 2, 3, 0]]
+
+
+def test_road_correction():
+    instance = ECVRPSolution([], [0, 3, 1, 2, 0], test_instance_2)
+    roads = instance.get_roads()
+    new_road = instance._road_correction(roads[0], instance.get_instance().get_ev_battery())
+    assert new_road == [0, 3, 0, 1, 2, 0]

--- a/test/cvrp/test_ecvrp.py
+++ b/test/cvrp/test_ecvrp.py
@@ -64,8 +64,9 @@ test_instance = ECVRPInstance(
 
 
 def test_road_building():
-    """ Test the road building process: ensure the count is right
+    """ Test the road building process: ensure the count is right.
     """
+
     solutions = {
         2: [0, 1, 2, 3, 0, 4, 5, 0],
         1: [0, 1, 0],
@@ -78,8 +79,9 @@ def test_road_building():
 
 
 def test_road_content():
-    """ Test the road building process: ensure the content of the roads are goods
+    """ Test the road building process: ensure the content of the roads are goods.
     """
+
     roads_expected = [
         {
             "source": [0, 1, 2, 3, 0, 4, 5, 0],
@@ -98,8 +100,9 @@ def test_road_content():
 
 
 def test_fitness():
-    """ Test if the fitness computation is good
+    """ Test if the fitness computation is good.
     """
+
     instance = ECVRPSolution([], [0, 2, 3, 0, 4, 1, 0], test_instance)
     assert instance.get_fitness() == 8
 
@@ -111,8 +114,9 @@ def test_fitness():
 
 
 def test_is_valid():
-    """ test if the is_valid method works as expected
+    """ Test if the is_valid method works as expected.
     """
+
     town = TownUnicityValidator()
     capacity = CapacityValidator()
     count = VehiculeCountValidator()
@@ -153,8 +157,9 @@ def test_is_valid():
 
 
 def test_copy():
-    """ Test if the copy keyword works as expected
+    """ Test if the copy keyword works as expected.
     """
+
     town = TownUnicityValidator()
     capacity = CapacityValidator()
     count = VehiculeCountValidator()
@@ -183,8 +188,9 @@ def test_copy():
 
 
 def test_d_matrix():
-    """ Test the distance matrix of the ECVRPInstance class
+    """ Test the distance matrix of the ECVRPInstance class.
     """
+
     assert test_instance.get_distance(0, 1) == 1
     assert test_instance.get_distance(0, 2) == 2
     assert test_instance.get_distance(1, 0) == 3
@@ -196,8 +202,9 @@ def test_depot():
 
 
 def test_demand():
-    """ Test the `get_demand` function of the ECVRPInstance class
+    """ Test the `get_demand` function of the ECVRPInstance class.
     """
+
     assert test_instance.get_demand(2) == 5
 
     with pytest.raises(KeyError):

--- a/test/cvrp/test_ecvrp.py
+++ b/test/cvrp/test_ecvrp.py
@@ -4,9 +4,10 @@
 This module holds tests for the cvrp.ecvrp module.
 
 @author: Cyril Obrecht
+@author: Marie Aspro
 @license: GPL-3
-@date: 2022-11-02
-@version: 0.1
+@date: 2022-11-28
+@version: 0.2
 """
 
 # CVRP
@@ -28,6 +29,7 @@ This module holds tests for the cvrp.ecvrp module.
 
 from copy import copy
 import pytest
+import random
 # pylint: disable=E0401 # False positive. This import works fine.
 from src.cvrp.ecvrp import ECVRPSolution, ECVRPInstance
 from src.cvrp.constraints_validators import\
@@ -214,3 +216,19 @@ def test_demand():
 def test_charger():
     assert test_instance.is_charger(1)
     assert not test_instance.is_charger(2)
+
+
+def test_crossover():
+    random.seed(8)
+
+    parent_1 = ECVRPSolution([], [0, 4, 2, 0, 3, 1, 0], test_instance)
+    parent_2 = ECVRPSolution([], [0, 2, 3, 0, 1, 4, 0], test_instance)
+
+    [enfant_1, enfant_2] = parent_1.crossover(parent_2)
+
+    assert enfant_1.get_points() == (0, 0, 0)
+    assert enfant_2.get_points() == (0, 0, 0)
+
+
+def test_mutation():
+    assert True

--- a/test/cvrp/test_json_io.py
+++ b/test/cvrp/test_json_io.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+
+"""
+This module holds tests for the cvrp.json_io module.
+
+@author: Cyril Obrecht
+@license: GPL-3
+@date: 2022-11-02
+@version: 0.1
+"""
+
+# CVRP
+# Copyright (C) 2022  A.Marie, K.Sonia, M.Jean, O.Cyril, V.Axel
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import time
+from pathlib import Path
+# pylint: disable=E0401 # False positive. This import works fine.
+from src.cvrp.json_io import JsonWriter, read_json
+from src.cvrp.ecvrp import ECVRPSolution, ECVRPInstance
+
+
+test_instance = ECVRPInstance(
+    [
+        [0, 1, 2, 2, 2],
+        [3, 0, 2, 1, 2],
+        [1, 2, 0, 2, 1],
+        [3, 1, 2, 0, 2],
+        [1, 3, 1, 2, 0]
+    ],
+    0,
+    {1},
+    {
+        2: 5,
+        3: 4,
+        4: 6
+    },
+    1,
+    3,
+    3,
+    12,
+    12,
+    {
+        2: (),
+        3: (),
+        4: ()
+    }
+)
+
+
+def test_meta_writing(tmpdir: Path):
+    """ writes meta data to the JSON file format
+    """
+    writer = JsonWriter(
+        str(tmpdir),
+        "writter",
+        "bench_test"
+    )
+    writer.dump()
+
+
+def test_snapshot_writting(tmpdir: Path):
+    """ writes meta data and a snapshot to the JSON file format
+    """
+    writer = JsonWriter(
+        str(tmpdir),
+        "writter_snap",
+        "bench_test"
+    )
+
+    writer.add_snapshot([
+        ECVRPSolution([], [0, 1, 2, 3, 0, 4, 0], test_instance),
+        ECVRPSolution([], [0, 1, 0, 2, 0, 3, 0], test_instance),
+        ECVRPSolution([], [0, 1, 0, 2, 0, 3, 0, 4, 0], test_instance)
+    ], time.thread_time())
+    writer.dump()
+
+    assert True
+
+
+def test_snapshots_writting(tmpdir: Path):
+    """ writes meta data and snapshots to the JSON file format
+    """
+    writer = JsonWriter(
+        str(tmpdir),
+        "writter_snaps",
+        "bench_test"
+    )
+    for _ in range(9):
+        writer.add_snapshot([
+            ECVRPSolution([], [0, 1, 2, 3, 0, 4, 0], test_instance),
+            ECVRPSolution([], [0, 1, 0, 2, 0, 3, 0, 4, 0], test_instance),
+            ECVRPSolution([], [0, 1, 0, 2, 0, 3, 0], test_instance)
+        ], time.thread_time())
+    writer.dump()
+
+    assert True
+
+
+def test_snapshots_io(tmpdir: Path):
+    """ writes meta data and snapshots to the JSON file format
+    """
+    writer = JsonWriter(
+        str(tmpdir),
+        "writter_snaps",
+        "bench_test"
+    )
+    for _ in range(9):
+        writer.add_snapshot([
+            ECVRPSolution([], [0, 1, 2, 3, 0, 4, 0], test_instance),
+            ECVRPSolution([], [0, 1, 0, 2, 0, 3, 0, 4, 0], test_instance),
+            ECVRPSolution([], [0, 1, 0, 2, 0, 3, 0], test_instance)
+        ], time.thread_time())
+    writer.dump()
+
+    data = read_json(str(tmpdir), "writter_snaps")
+
+    assert data["bench_id"] == "bench_test"
+    assert len(data["snapshots"]) == 9
+
+    assert "individuals" in data["snapshots"][0]
+    assert "time" in data["snapshots"][0]
+
+    assert len(data["snapshots"][0]["individuals"]) == 3
+    assert "solution" in data["snapshots"][0]["individuals"][0]
+    assert "fitness" in data["snapshots"][0]["individuals"][0]
+
+    assert data["snapshots"][0]["individuals"][0]["solution"] == [0, 1, 2, 3, 0, 4, 0]
+    assert data["snapshots"][0]["individuals"][1]["solution"] == [0, 1, 0, 2, 0, 3, 0, 4, 0]
+    assert data["snapshots"][0]["individuals"][2]["solution"] == [0, 1, 0, 2, 0, 3, 0]

--- a/test/cvrp/test_validators.py
+++ b/test/cvrp/test_validators.py
@@ -64,8 +64,7 @@ test_instance = ECVRPInstance(
 
 
 def test_battery_validator():
-    """ Test if the battery validatation works
-    """
+    """ Test if the battery validatation works."""
     validator = BatteryTWValidator()
     assert validator.is_valid(ECVRPSolution([], [0, 2, 3, 0], test_instance))
     assert validator.is_valid(ECVRPSolution([], [0, 2, 3, 2, 0], test_instance))
@@ -73,8 +72,7 @@ def test_battery_validator():
 
 
 def test_time_windows():
-    """ Test if the time window validation works
-    """
+    """ Test if the time window validation works."""
     validator = BatteryTWValidator()
 
     assert validator.is_valid(ECVRPSolution([], [0, 2, 3, 0, 4, 1, 0], test_instance))
@@ -83,8 +81,7 @@ def test_time_windows():
 
 
 def test_vehicule_count():
-    """ Test if the vehicule count validator works
-    """
+    """ Test if the vehicule count validator works."""
     validator = VehiculeCountValidator()
 
     assert validator.is_valid(ECVRPSolution([], [0, 2, 3, 0, 4, 1, 0], test_instance))
@@ -93,22 +90,20 @@ def test_vehicule_count():
 
 
 def test_town_unicity():
-    """ Test if the vehicule count validator works
-    """
+    """ Test if the vehicule count validator works."""
     validator = TownUnicityValidator()
 
     assert validator.is_valid(ECVRPSolution([], [0, 2, 3, 0, 4, 1, 0], test_instance))
-    assert validator.is_valid(ECVRPSolution([], [0, 2, 3, 0, 4, 1, 0, 0], test_instance))
-    assert validator.is_valid(ECVRPSolution([], [0, 2, 3, 0, 4, 1, 0, 0, 0], test_instance))
-    assert validator.is_valid(ECVRPSolution([], [0, 2, 3, 0, 4, 1, 0, 0, 1, 0], test_instance))
     assert not validator.is_valid(ECVRPSolution([], [0, 2, 3, 0, 4, 4, 1, 0, 0, 0], test_instance))
+    assert validator.is_valid(ECVRPSolution([], [0, 2, 3, 0, 4, 1, 0, 0], test_instance))
     assert not validator.is_valid(ECVRPSolution([], [0, 2, 3, 0, 4, 1, 0, 0, 4, 0], test_instance))
+    assert validator.is_valid(ECVRPSolution([], [0, 2, 3, 0, 4, 1, 0, 0, 0], test_instance))
     assert not validator.is_valid(ECVRPSolution([], [0, 2, 3, 0, 1, 0, 0, 1, 0], test_instance))
+    assert validator.is_valid(ECVRPSolution([], [0, 2, 3, 0, 4, 1, 0, 0, 1, 0], test_instance))
 
 
 def test_capacity():
-    """ Test if the vehicule capacity validator works
-    """
+    """ Test if the vehicule capacity validator works."""
     validator = CapacityValidator()
     assert validator.is_valid(ECVRPSolution([], [0, 2, 3, 0, 4, 0], test_instance))
     assert not validator.is_valid(ECVRPSolution([], [0, 2, 3, 4, 0], test_instance))

--- a/test/server/__init__.py
+++ b/test/server/__init__.py
@@ -1,1 +1,2 @@
 # TODO: Remove this file once a test is create. this file is useless.
+"""Good documentation should be placed here."""


### PR DESCRIPTION
## What has been done 


### Crossover on the ecvrp file:
#### Creation of the method crossover, include other methods:
- **remove_point** (_private_) : remove a precised point in a solution for the crossover process
- **best_place_for** (_public_) : find the best place to add a point in a new road at the end of the crossover process


### Mutation on the ecvrp file:
#### Creation of the method mutation, include other methods:
- **two_opt** (_private_): algorithm which find the best mutation for this road by calculating the distance for each mutation of road
- **reversed_content** (_public_): reverse the content of a road between the point 1 and 2 (included)

### Methods used for both:
- **tuple_to_list** (_private_): convert a tuple[tuple[int] into a list[list[int]] because tuple are immutable
- **pull_off_chargers** (_private_) : remove all the chargers from a solution
- **road_correction** (_protected_): add the closest electric charge between 2 points
- **closest_charger** (_private_): find the closest charger of a point
- **delete_empty_road** (_public_): delete empty road which are represented by [0, 0] 
- **merge_roads** (_private_): merge roads to obtain a solution in a simple list

### Test on the test_ecvrp file:
- A new instance has been created to test new methods
- Crossover has been tested
- Mutation has been tested
- Empty road and road correction have been tested to cover some tricky cases

## What has not been done
- Unit tests for each method
- Recreating a situation where the best place is to add a road if all vehicles are not monopolized, it would cover the lines 169, 391 and 399

## Coverage

Name | Stmts | Miss |  Cover | Missing
|-|-|-|-|-|
src\cvrp\ecvrp.py  | 270 | 3 | 99%  | 169, 391, 399
TOTAL | 528 | 3  |  99% |

